### PR TITLE
Updating to latest version of Cucumber

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ task cucumber() {
     dependsOn assemble
     doLast {
         javaexec {
-            main = "cucumber.cli.Main"
+            main = "cucumber.api.cli.Main"
             classpath = configurations.cucumberRuntime
             args = ['-f', 'pretty', '--glue', 'src/test/groovy', 'src/test/resources']
 
@@ -26,7 +26,7 @@ task cucumber() {
 
 dependencies {
     // Groovy library for groovy building!
-    groovy 'org.codehaus.groovy:groovy-all:2.0.0-beta-2'
+    groovy 'org.codehaus.groovy:groovy-all:2.1.0'
 
     /*
    In order to work around a really flagrant bug ( http://issues.gradle.org/browse/GRADLE-732 )
@@ -39,8 +39,8 @@ dependencies {
     cucumberRuntime files("${jar.archivePath}")
 
     testCompile 'junit:junit:4.10'
-    testCompile 'info.cukes:cucumber-junit:1.0.9'
-    testCompile 'info.cukes:cucumber-groovy:1.0.9'
+    testCompile 'info.cukes:cucumber-junit:1.1.2'
+    testCompile 'info.cukes:cucumber-groovy:1.1.2'
 }
 
 repositories {

--- a/src/test/groovy/calc/CalculatorSteps.groovy
+++ b/src/test/groovy/calc/CalculatorSteps.groovy
@@ -2,8 +2,8 @@ package calc
 
 import calc.Calculator
 
-this.metaClass.mixin(cucumber.runtime.groovy.Hooks)
-this.metaClass.mixin(cucumber.runtime.groovy.EN)
+this.metaClass.mixin(cucumber.api.groovy.Hooks)
+this.metaClass.mixin(cucumber.api.groovy.EN)
 
 class CustomWorld {
     String customMethod() {

--- a/src/test/java/calc/RunCukesTest.java
+++ b/src/test/java/calc/RunCukesTest.java
@@ -1,6 +1,6 @@
 package calc;
 
-import cucumber.junit.Cucumber;
+import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)


### PR DESCRIPTION
I was using this project as an example to base my own Cucumber project under.  Unfortunately, it took longer than it should have to get updated to the latest version of cucumber-jvm (due to the API changes).

I figured them out, and figured I'd submit this so that others won't be confused when trying to use the latest version :)
