### PR TITLE
travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ language: groovy
 sudo: false
 
 script:
-	- gradle cucumber
+  - gradle cucumber
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: groovy
+
+sudo: false
+
+script:
+	- gradle cucumber

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 A sample cucumber-jvm groovy project built using gradle!
 
+[![Build Status](https://travis-ci.org/d-led/cucumber-jvm-groovy-example.svg?branch=master)](https://travis-ci.org/d-led/cucumber-jvm-groovy-example)
+
 ### Versions
  * Gradle: 1.7 
  * Cucumber-jvm: as listed in the build.gradle file!


### PR DESCRIPTION
given the today's dockerized travis-ci build, it might make sense to have a travis-ci hook and a badge for quick tryouts. Substitute `d-led` in the badge for the correct name after configuring travis-ci
